### PR TITLE
[ConcertService Test] ConcertServiceTest 코드 구현 #11

### DIFF
--- a/src/main/java/com/trove/ticket_trove/model/entity/concert/ConcertEntity.java
+++ b/src/main/java/com/trove/ticket_trove/model/entity/concert/ConcertEntity.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "concert",
         uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"concert_name", "performer", "deleted_at"})
+        @UniqueConstraint(columnNames = {"concert_name", "performer","show_start", "deleted_at"})
 })
 @SQLDelete(sql = "UPDATE concert " +
         "SET deleted_at = CURRENT_TIMESTAMP " +

--- a/src/main/java/com/trove/ticket_trove/model/storage/concert/ConcertRepository.java
+++ b/src/main/java/com/trove/ticket_trove/model/storage/concert/ConcertRepository.java
@@ -14,4 +14,6 @@ public interface ConcertRepository extends JpaRepository<ConcertEntity, Long> {
     @Query("SELECT c FROM ConcertEntity c WHERE c.concertName = :concertName AND c.performer = :performer AND c.deletedAt IS NULL")
     Optional<ConcertEntity> findByConcertNameAndPerformer(@Param("concertName") String concertName, @Param("performer") String performer);
 
+    @Query(value = "SELECT * FROM concert c WHERE id = :concertId AND deleted_at IS NOT NULL", nativeQuery = true)
+    Optional<ConcertEntity> findByDeletedId(@Param("concertId") Long concertId);
 }

--- a/src/test/java/com/trove/ticket_trove/service/concert/ConcertServiceDynamicTest.java
+++ b/src/test/java/com/trove/ticket_trove/service/concert/ConcertServiceDynamicTest.java
@@ -1,0 +1,138 @@
+package com.trove.ticket_trove.service.concert;
+
+import com.trove.ticket_trove.dto.concert.request.ConcertCreateRequest;
+import com.trove.ticket_trove.dto.concert.request.ConcertUpdateRequest;
+import com.trove.ticket_trove.dto.concert.response.ConcertInfoResponse;
+import com.trove.ticket_trove.model.entity.concert.ConcertEntity;
+import com.trove.ticket_trove.model.storage.concert.ConcertRepository;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+@SpringBootTest
+class ConcertServiceDynamicTest {
+
+    @Autowired
+    private ConcertService concertService;
+    @Autowired
+    private ConcertRepository concertRepository;
+    @TestFactory
+    Stream<DynamicTest> concertServiceDynamicTest(){
+        List<ConcertInfoResponse> concertList = new ArrayList<>();
+        AtomicInteger count = new AtomicInteger(0);
+        return Stream.of(
+                dynamicTest("콘서트를 생성 후 조회를 통해 생성과 조회를 성공한다.", () -> {
+                    //given
+                    var concertCreateReq = new ConcertCreateRequest(
+                            "잠실 경기장",
+                            "나얼",
+                            LocalDateTime.of(2024,10,26,15,0),
+                            LocalDateTime.of(2024,10,26,22,0));
+                    var concertEntity = ConcertEntity.builder()
+                            .id(count.incrementAndGet())
+                            .concertName(concertCreateReq.concertName())
+                            .performer(concertCreateReq.performer())
+                            .showStart(concertCreateReq.showStart())
+                            .showEnd(concertCreateReq.showEnd())
+                            .build();
+
+                    //when
+                    //콘서트 생성
+                    concertService.addConcert(concertCreateReq);
+                    concertList.add(ConcertInfoResponse.from(concertEntity));
+                    //콘서트 조회
+                    var concertResponse = concertService
+                            .searchConcert((long) concertList.size());
+
+                    //then
+                    assertNotNull(concertResponse);
+                    assertEquals(concertList.get(count.get()-1).id(), concertResponse.id());
+                    assertEquals(concertList.get(count.get()-1).concertName(), concertResponse.concertName());
+                    assertEquals(concertList.get(count.get()-1).performer(), concertResponse.performer());
+                    assertEquals(concertList.get(count.get()-1).showStart(), concertResponse.showStart());
+                    assertEquals(concertList.get(count.get()-1).showEnd(), concertResponse.showEnd());
+                }),
+                dynamicTest("콘서트 전체 조회를 성공한다.", () -> {
+                    //given
+                    var concertCreateReq = new ConcertCreateRequest(
+                            "목동 경기장",
+                            "박효신",
+                            LocalDateTime.of(2024,12,25,15,0),
+                            LocalDateTime.of(2024,12,25,22,0));
+                    var concertEntity = ConcertEntity.builder()
+                            .id(count.incrementAndGet())
+                            .concertName(concertCreateReq.concertName())
+                            .performer(concertCreateReq.performer())
+                            .showStart(concertCreateReq.showStart())
+                            .showEnd(concertCreateReq.showEnd())
+                            .build();
+                    concertService.addConcert(concertCreateReq);
+                    concertList.add(ConcertInfoResponse.from(concertEntity));
+
+                    //when
+                    var concertResponses = concertService.searchConcerts();
+
+                    //then
+                    assertNotNull(concertResponses);
+                    assertEquals(concertList.size(), concertResponses.size());
+                    var concertArray = concertList.toArray();
+                    var responseArray = concertResponses.toArray();
+                    assertArrayEquals(concertArray, responseArray);
+                }),
+                dynamicTest("콘서트 수정을 성공한다.", () -> {
+                    //given
+                    var concertUpdateReq = new ConcertUpdateRequest(
+                            2L,
+                            "잠실 경기장",
+                            "박효신",
+                            LocalDateTime.of(2024,12,25,13,0),
+                            LocalDateTime.of(2024,12,25,21,0));
+                    var concert = concertList.get(concertUpdateReq.concertId().intValue() - 1);
+
+                    //when
+                    var concertInfoResponse = concertService.updateConcert(concertUpdateReq);
+
+                    //then
+                    assertNotNull(concertInfoResponse);
+                    assertEquals(concert.performer(), concertInfoResponse.performer());
+                    assertEquals(concert.id(), concertInfoResponse.id());
+
+                    assertNotEquals(concert.concertName(), concertInfoResponse.concertName());
+                    assertNotEquals(concert.showStart(), concertInfoResponse.showStart());
+                    assertNotEquals(concert.showEnd(), concertInfoResponse.showEnd());
+                    //수정된 데이터 저장
+                    concertList.remove(concert);
+                    concertList.add(ConcertInfoResponse.from(ConcertEntity.builder()
+                                    .id(concertUpdateReq.concertId())
+                                    .concertName(concertUpdateReq.concertName())
+                                    .performer(concertUpdateReq.performer())
+                                    .showStart(concertUpdateReq.showStart())
+                                    .showEnd(concertUpdateReq.showEnd())
+                                    .build())
+                    );
+                }),
+                dynamicTest("콘서트 정보를 소프트 삭제한다.", () -> {
+                    //when
+                    concertService.deleteConcert(2L);
+                    var responses = concertService.searchConcerts();
+                    //삭제된 콘서트 조회
+                    var deleteConcert = concertRepository.findByDeletedId(2L);
+
+                    //then
+                    assertNotNull(deleteConcert);
+                    assertNotEquals(concertList.size(), responses.size());
+                    concertList.removeLast();
+                })
+        );
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -8,6 +8,11 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
 logging:
   level:
     org.hibernate.orm.jdbc.bind: TRACE


### PR DESCRIPTION
1. ConcertEntity 복합키로 show_start를 추가
2. ConcertRepository에서 소프트 삭제가 된 로우를 검색하는 findByDeletedId()메소드 추가
3. ConcertServiceDynamicTest
  - 콘서트를 생성 후 조회를 통해 생성과 조회를 성공한다.
  - 콘서트 전체 조회를 성공한다.
  - 콘서트 수정을 성공한다.
  - 콘서트 정보를 소프트 삭제한다.

close #11 