### PR TITLE
[예외 처리] SeatGradeEntity와 TicketEntity에 대한 예외처리 #13

### DIFF
--- a/src/main/java/com/trove/ticket_trove/controller/concert/ConcertController.java
+++ b/src/main/java/com/trove/ticket_trove/controller/concert/ConcertController.java
@@ -38,10 +38,10 @@ public class ConcertController {
     }
 
     //콘서트 단건 조회
-    @GetMapping("/{id}")
+    @GetMapping("/{concertId}")
     public ResponseEntity<ConcertInfoResponse> getConcert(
-            @PathVariable Long id) {
-        var concertResponse = concertService.searchConcert(id);
+            @PathVariable Long concertId) {
+        var concertResponse = concertService.searchConcert(concertId);
         return ResponseEntity.ok(concertResponse);
     }
 
@@ -57,11 +57,11 @@ public class ConcertController {
     }
 
     //콘서트 삭제
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/{concertId}")
     public ResponseEntity<HttpStatus> deleteConcert(
-            @PathVariable Long id
+            @PathVariable Long concertId
     ) {
-        concertService.deleteConcert(id);
+        concertService.deleteConcert(concertId);
         return ResponseEntity.ok(HttpStatus.OK);
     }
 

--- a/src/main/java/com/trove/ticket_trove/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/trove/ticket_trove/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.trove.ticket_trove.exception.concert.ConcertExistsException;
 import com.trove.ticket_trove.exception.dto.ClientErrorResponse;
 import com.trove.ticket_trove.exception.member.MemberExistsException;
 import com.trove.ticket_trove.exception.member.MemberNotFoundException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -48,5 +49,16 @@ public class GlobalExceptionHandler {
                         e.getHttpStatus(),
                         e.getMessage()),
                 e.getHttpStatus());
+    }
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ClientErrorResponse> exception(
+            Exception e
+    ) {
+        return new ResponseEntity<>(
+                new ClientErrorResponse(
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        e.getMessage()),
+                HttpStatus.INTERNAL_SERVER_ERROR
+        );
     }
 }

--- a/src/main/java/com/trove/ticket_trove/exception/member/MemberExistsException.java
+++ b/src/main/java/com/trove/ticket_trove/exception/member/MemberExistsException.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 public class MemberExistsException extends ClientErrorException {
 
     public MemberExistsException() {
-        super(HttpStatus.CONFLICT, "Member already exists");
+        super(HttpStatus.BAD_REQUEST, "Member already exists");
     }
     public MemberExistsException(String email) {
         super(HttpStatus.BAD_REQUEST, "email : " + email + " already exists");

--- a/src/main/java/com/trove/ticket_trove/exception/seatgrade/SeatGradeNotFoundException.java
+++ b/src/main/java/com/trove/ticket_trove/exception/seatgrade/SeatGradeNotFoundException.java
@@ -1,0 +1,14 @@
+package com.trove.ticket_trove.exception.seatgrade;
+
+import com.trove.ticket_trove.exception.ClientErrorException;
+import org.springframework.http.HttpStatus;
+
+public class SeatGradeNotFoundException extends ClientErrorException {
+
+    public SeatGradeNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "현재 공연장에 있는 등급이 아닙니다.");
+    }
+    public SeatGradeNotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/trove/ticket_trove/exception/seatgrade/SeatNumberValidationException.java
+++ b/src/main/java/com/trove/ticket_trove/exception/seatgrade/SeatNumberValidationException.java
@@ -1,0 +1,10 @@
+package com.trove.ticket_trove.exception.seatgrade;
+
+import com.trove.ticket_trove.exception.ClientErrorException;
+import org.springframework.http.HttpStatus;
+
+public class SeatNumberValidationException extends ClientErrorException {
+    public SeatNumberValidationException() {
+        super(HttpStatus.BAD_REQUEST, "현재 등급의 좌석번호와 맞지 않습니다.");
+    }
+}

--- a/src/main/java/com/trove/ticket_trove/exception/ticket/TicketExistsException.java
+++ b/src/main/java/com/trove/ticket_trove/exception/ticket/TicketExistsException.java
@@ -1,0 +1,12 @@
+package com.trove.ticket_trove.exception.ticket;
+
+import com.trove.ticket_trove.exception.ClientErrorException;
+import org.springframework.http.HttpStatus;
+
+public class TicketExistsException extends ClientErrorException {
+
+    public TicketExistsException() {
+        super(HttpStatus.BAD_REQUEST, "티켓이 존재합니다.");
+    }
+
+}

--- a/src/main/java/com/trove/ticket_trove/exception/ticket/TicketNotFoundException.java
+++ b/src/main/java/com/trove/ticket_trove/exception/ticket/TicketNotFoundException.java
@@ -1,0 +1,15 @@
+package com.trove.ticket_trove.exception.ticket;
+
+import com.trove.ticket_trove.exception.ClientErrorException;
+import org.springframework.http.HttpStatus;
+
+public class TicketNotFoundException extends ClientErrorException {
+
+    public TicketNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "해당 티켓이 없습니다.");
+    }
+
+    public TicketNotFoundException(HttpStatus httpStatus, String message) {
+        super(httpStatus, message);
+    }
+}


### PR DESCRIPTION
[예외 처리] SeatGradeEntity와 TicketEntity에 대한 예외처리
 - 커스텀 예외 이외의 처리를 표시하기위해 Exception.class 예외 처리 수정
[클래스 수정] ConcertController UpdateMapping과 DeleteMapping PathVariable수정
 - 컨트롤러에서 id변수명을 좀 더 명확하게 수정 concertId
[클래스 수정] MemberExistsException HttpStatus.BAD_REQUEST 수정
  - HttpStatus 코드가 잘못 되어 수정

close #13 