### PR TITLE
[API 구현] ReservationAPI 구현 #15

### DIFF
--- a/src/main/java/com/trove/ticket_trove/controller/reservation/ReservationController.java
+++ b/src/main/java/com/trove/ticket_trove/controller/reservation/ReservationController.java
@@ -1,0 +1,70 @@
+package com.trove.ticket_trove.controller.reservation;
+
+import com.trove.ticket_trove.dto.ticket.request.TicketCreateRequest;
+import com.trove.ticket_trove.dto.ticket.request.TicketDeleteRequest;
+import com.trove.ticket_trove.dto.ticket.request.TicketMemberEmailRequest;
+import com.trove.ticket_trove.dto.ticket.request.TicketSearchRequest;
+import com.trove.ticket_trove.dto.ticket.response.TicketInfoAdminResponse;
+import com.trove.ticket_trove.dto.ticket.response.TicketInfoResponse;
+import com.trove.ticket_trove.dto.ticket.response.TicketReservationResponse;
+import com.trove.ticket_trove.service.reservation.ReservationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/reservation")
+public class ReservationController {
+    private final ReservationService reservationService;
+
+    public ReservationController(ReservationService reservationService) {
+        this.reservationService = reservationService;
+    }
+    //티켓 예매
+    @PostMapping
+    public ResponseEntity<TicketReservationResponse> reserve(
+            @RequestBody
+            TicketCreateRequest request
+    ) {
+        var ticketResponse = reservationService.reserve(request);
+        return ResponseEntity.ok(ticketResponse);
+    }
+    //유저 티켓 전체 조회
+    @PostMapping("/member-tickets")
+    public ResponseEntity<List<TicketInfoResponse>> searchMemberTickets(
+            @RequestBody
+            TicketMemberEmailRequest request
+    ) {
+        var memberTicketsResponse =
+                reservationService.searchTickets(request.email());
+        return ResponseEntity.ok(memberTicketsResponse);
+    }
+    //유저 티켓 단건 조회
+    @PostMapping("/member-ticket")
+    public ResponseEntity<TicketInfoResponse> searchTicket(
+            @RequestBody
+            TicketSearchRequest request
+    ) {
+        var ticketInfoResponse = reservationService.searchTicket(request);
+        return ResponseEntity.ok(ticketInfoResponse);
+    }
+    //공연장 티켓 전체 조회
+    @GetMapping("/concert-tickets/{concertId}")
+    public ResponseEntity<List<TicketInfoAdminResponse>> searchConcertTickets(
+            @PathVariable Long concertId
+    ) {
+        var concertTicketsResponse = reservationService.searchConcertTickets(concertId);
+        return ResponseEntity.ok(concertTicketsResponse);
+    }
+    //티켓 취소
+    @DeleteMapping
+    public ResponseEntity<HttpStatus> cancelTicket(
+            @RequestBody
+            TicketDeleteRequest request
+    ) {
+        reservationService.cancelTicket(request);
+        return ResponseEntity.ok(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/trove/ticket_trove/dto/concert/request/ConcertCreateRequest.java
+++ b/src/main/java/com/trove/ticket_trove/dto/concert/request/ConcertCreateRequest.java
@@ -12,5 +12,16 @@ public record ConcertCreateRequest(
         @NotBlank
         LocalDateTime showStart,
         @NotBlank
-        LocalDateTime showEnd) {
+        LocalDateTime showEnd,
+        @NotBlank
+        GradeType[] gradeType
+        ) {
+        public static record GradeType(
+                @NotBlank
+                String grade,
+                @NotBlank
+                Integer price,
+                @NotBlank
+                Integer totalSeat) {}
 }
+

--- a/src/main/java/com/trove/ticket_trove/dto/concert/response/ConcertInfoResponse.java
+++ b/src/main/java/com/trove/ticket_trove/dto/concert/response/ConcertInfoResponse.java
@@ -5,7 +5,7 @@ import com.trove.ticket_trove.model.entity.concert.ConcertEntity;
 import java.time.LocalDateTime;
 
 public record ConcertInfoResponse(
-        Long id,
+        Long concertId,
         String concertName,
         String performer,
         LocalDateTime showStart,

--- a/src/main/java/com/trove/ticket_trove/dto/concert/response/ConcertUpdateResponse.java
+++ b/src/main/java/com/trove/ticket_trove/dto/concert/response/ConcertUpdateResponse.java
@@ -5,7 +5,7 @@ import com.trove.ticket_trove.model.entity.concert.ConcertEntity;
 import java.time.LocalDateTime;
 
 public record ConcertUpdateResponse(
-        Long id,
+        Long concertId,
         String concertName,
         String performer,
         LocalDateTime showStart,

--- a/src/main/java/com/trove/ticket_trove/dto/member/request/MemberLoginRequest.java
+++ b/src/main/java/com/trove/ticket_trove/dto/member/request/MemberLoginRequest.java
@@ -1,4 +1,12 @@
 package com.trove.ticket_trove.dto.member.request;
 
-public record MemberLoginRequest(String email, String password) {
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberLoginRequest(
+        @NotBlank
+        @Email
+        String email,
+        @NotBlank
+        String password) {
 }

--- a/src/main/java/com/trove/ticket_trove/dto/member/request/MemberSignupRequest.java
+++ b/src/main/java/com/trove/ticket_trove/dto/member/request/MemberSignupRequest.java
@@ -1,19 +1,18 @@
 package com.trove.ticket_trove.dto.member.request;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
 public record MemberSignupRequest(
-    String name,
-    @Email
-    String email,
-    String password,
-    @Size(min = 1, max = 1)
-    String gender,
-    @Min(0)
-    @Max(150)
-    Integer age) {
+        @NotBlank
+        String name,
+        @Email
+        String email,
+        String password,
+        @Size(min = 1, max = 1)
+        String gender,
+        @Min(0)
+        @Max(150)
+        Integer age
+) {
 
 }

--- a/src/main/java/com/trove/ticket_trove/dto/ticket/request/TicketCreateRequest.java
+++ b/src/main/java/com/trove/ticket_trove/dto/ticket/request/TicketCreateRequest.java
@@ -1,0 +1,14 @@
+package com.trove.ticket_trove.dto.ticket.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TicketCreateRequest(
+        @NotBlank
+        Long concertId,
+        @NotBlank
+        String seatGrade,
+        @NotBlank
+        Integer seatNumber,
+        @NotBlank
+        String email) {
+}

--- a/src/main/java/com/trove/ticket_trove/dto/ticket/request/TicketDeleteRequest.java
+++ b/src/main/java/com/trove/ticket_trove/dto/ticket/request/TicketDeleteRequest.java
@@ -1,0 +1,15 @@
+package com.trove.ticket_trove.dto.ticket.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TicketDeleteRequest(
+        @NotBlank
+        Long concertId,
+        @NotBlank
+        String seatGrade,
+        @NotBlank
+        Integer seatNumber,
+        @NotBlank
+        String email
+) {
+}

--- a/src/main/java/com/trove/ticket_trove/dto/ticket/request/TicketMemberEmailRequest.java
+++ b/src/main/java/com/trove/ticket_trove/dto/ticket/request/TicketMemberEmailRequest.java
@@ -1,0 +1,9 @@
+package com.trove.ticket_trove.dto.ticket.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TicketMemberEmailRequest(
+        @NotBlank
+        String email
+) {
+}

--- a/src/main/java/com/trove/ticket_trove/dto/ticket/request/TicketSearchRequest.java
+++ b/src/main/java/com/trove/ticket_trove/dto/ticket/request/TicketSearchRequest.java
@@ -1,0 +1,15 @@
+package com.trove.ticket_trove.dto.ticket.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TicketSearchRequest(
+        @NotBlank
+        Long concertId,
+        @NotBlank
+        String seatGrade,
+        @NotBlank
+        Integer seatNumber,
+        @NotBlank
+        String email
+) {
+}

--- a/src/main/java/com/trove/ticket_trove/dto/ticket/response/TicketInfoAdminResponse.java
+++ b/src/main/java/com/trove/ticket_trove/dto/ticket/response/TicketInfoAdminResponse.java
@@ -1,0 +1,39 @@
+package com.trove.ticket_trove.dto.ticket.response;
+
+import com.trove.ticket_trove.model.entity.ticket.TicketEntity;
+
+import java.time.LocalDateTime;
+
+public record TicketInfoAdminResponse(
+        Long ticketId,
+        String name,
+        String email,
+        String concertName,
+        String performer,
+        String grade,
+        Integer seatNumber,
+        Integer price,
+        LocalDateTime showStart,
+        LocalDateTime showEnd,
+        LocalDateTime createdAt,
+        LocalDateTime deletedAt
+) {
+    public static TicketInfoAdminResponse from(
+            TicketEntity ticketEntity
+    ) {
+        var concertEntity = ticketEntity.getConcertId();
+        return new TicketInfoAdminResponse(
+                ticketEntity.getId(),
+                ticketEntity.getMemberEmail().getName(),
+                ticketEntity.getMemberEmail().getEmail(),
+                concertEntity.getConcertName(),
+                concertEntity.getPerformer(),
+                ticketEntity.getSeatGrade().getGrade(),
+                ticketEntity.getSeatNumber(),
+                ticketEntity.getSeatGrade().getPrice(),
+                concertEntity.getShowStart(),
+                concertEntity.getShowEnd(),
+                ticketEntity.getCreatedAt(),
+                ticketEntity.getDeletedAt());
+    }
+}

--- a/src/main/java/com/trove/ticket_trove/dto/ticket/response/TicketInfoResponse.java
+++ b/src/main/java/com/trove/ticket_trove/dto/ticket/response/TicketInfoResponse.java
@@ -1,0 +1,31 @@
+package com.trove.ticket_trove.dto.ticket.response;
+
+import com.trove.ticket_trove.model.entity.ticket.TicketEntity;
+
+import java.time.LocalDateTime;
+
+public record TicketInfoResponse(
+        Long id,
+        String name,
+        String concertName,
+        String performer,
+        String grade,
+        Integer seatNumber,
+        LocalDateTime showStart,
+        LocalDateTime showEnd
+) {
+    public static TicketInfoResponse from(
+            TicketEntity ticketEntity
+    ) {
+        var concertEntity = ticketEntity.getConcertId();
+        return new TicketInfoResponse(
+                ticketEntity.getId(),
+                ticketEntity.getMemberEmail().getName(),
+                concertEntity.getConcertName(),
+                concertEntity.getPerformer(),
+                ticketEntity.getSeatGrade().getGrade(),
+                ticketEntity.getSeatNumber(),
+                concertEntity.getShowStart(),
+                concertEntity.getShowEnd());
+    }
+}

--- a/src/main/java/com/trove/ticket_trove/dto/ticket/response/TicketReservationResponse.java
+++ b/src/main/java/com/trove/ticket_trove/dto/ticket/response/TicketReservationResponse.java
@@ -1,0 +1,31 @@
+package com.trove.ticket_trove.dto.ticket.response;
+
+import com.trove.ticket_trove.model.entity.ticket.TicketEntity;
+
+import java.time.LocalDateTime;
+
+public record TicketReservationResponse(
+        Long id,
+        String name,
+        String concertName,
+        String performer,
+        String grade,
+        Integer seatNumber,
+        LocalDateTime showStart,
+        LocalDateTime showEnd
+) {
+    public static TicketReservationResponse from(
+            TicketEntity ticketEntity
+    ) {
+        var concertEntity = ticketEntity.getConcertId();
+        return new TicketReservationResponse(
+                ticketEntity.getId(),
+                ticketEntity.getMemberEmail().getName(),
+                concertEntity.getConcertName(),
+                concertEntity.getPerformer(),
+                ticketEntity.getSeatGrade().getGrade(),
+                ticketEntity.getSeatNumber(),
+                concertEntity.getShowStart(),
+                concertEntity.getShowEnd());
+    }
+}

--- a/src/main/java/com/trove/ticket_trove/model/entity/seat_grade/SeatGradeEntity.java
+++ b/src/main/java/com/trove/ticket_trove/model/entity/seat_grade/SeatGradeEntity.java
@@ -1,0 +1,74 @@
+package com.trove.ticket_trove.model.entity.seat_grade;
+
+
+import com.trove.ticket_trove.model.entity.concert.ConcertEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(
+        name = "seat_grade",
+        indexes = {
+            @Index(
+                    name = "idx_seat_grade_concert_id_grade",
+                    columnList = "concert_id, grade")
+        },
+        uniqueConstraints = @UniqueConstraint(columnNames = {"concert_id","grade", "price", "deleted_at"})
+)
+@SQLDelete(sql = "UPDATE seat_grade " +
+        "SET deleted_at = CURRENT_TIMESTAMP " +
+        "WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeatGradeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "concert_id")
+    private ConcertEntity concertId;
+    private String grade;
+    private Integer price;
+    private Integer totalSeat;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    private void prePersist() {
+        createdAt = LocalDateTime.now();
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public static SeatGradeEntity from(
+            ConcertEntity concertEntity,
+            String grade, Integer price, Integer totalSeat) {
+        return SeatGradeEntity.builder()
+                .concertId(concertEntity)
+                .grade(grade)
+                .price(price)
+                .totalSeat(totalSeat)
+                .build();
+    }
+}

--- a/src/main/java/com/trove/ticket_trove/model/entity/ticket/TicketEntity.java
+++ b/src/main/java/com/trove/ticket_trove/model/entity/ticket/TicketEntity.java
@@ -1,0 +1,93 @@
+package com.trove.ticket_trove.model.entity.ticket;
+
+
+import com.trove.ticket_trove.model.entity.concert.ConcertEntity;
+import com.trove.ticket_trove.model.entity.member.MemberEntity;
+import com.trove.ticket_trove.model.entity.seat_grade.SeatGradeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(
+        name = "ticket",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        columnNames = {
+                                "member_email", "seat_grade",
+                                "concert_id", "seat_number"
+                        })
+        },
+        indexes = {
+            @Index(name = "idx_ticket_conid_s_grade_s_number",
+                    columnList =
+                            "concert_id, seat_grade, " +
+                            "seat_number, member_email")
+        }
+)
+@SQLDelete(sql = "UPDATE ticket " +
+        "SET deleted_at = CURRENT_TIMESTAMP " +
+        "WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_email")
+    private MemberEntity memberEmail;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "concert_id")
+    private ConcertEntity concertId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_grade")
+    private SeatGradeEntity seatGrade;
+
+    @Column(name = "seat_number")
+    private Integer seatNumber;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    private void prePersist() {
+        createdAt = LocalDateTime.now();
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+    public static TicketEntity from(
+            MemberEntity memberEmail,
+            ConcertEntity concertId,
+            SeatGradeEntity seatGradeEntity,
+            Integer seatNumber
+    ) {
+        return TicketEntity.builder()
+                .memberEmail(memberEmail)
+                .concertId(concertId)
+                .seatGrade(seatGradeEntity)
+                .seatNumber(seatNumber)
+                .build();
+    }
+}

--- a/src/main/java/com/trove/ticket_trove/model/storage/seat_grade/SeatGradeRepository.java
+++ b/src/main/java/com/trove/ticket_trove/model/storage/seat_grade/SeatGradeRepository.java
@@ -1,0 +1,15 @@
+package com.trove.ticket_trove.model.storage.seat_grade;
+
+import com.trove.ticket_trove.model.entity.concert.ConcertEntity;
+import com.trove.ticket_trove.model.entity.seat_grade.SeatGradeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SeatGradeRepository extends JpaRepository<SeatGradeEntity, Long> {
+    Optional<SeatGradeEntity> findByConcertIdAndGrade(ConcertEntity concertEntity, String grade);
+
+    void deleteAllByConcertId(ConcertEntity concertEntity);
+}

--- a/src/main/java/com/trove/ticket_trove/model/storage/ticket/TicketRepository.java
+++ b/src/main/java/com/trove/ticket_trove/model/storage/ticket/TicketRepository.java
@@ -1,0 +1,34 @@
+package com.trove.ticket_trove.model.storage.ticket;
+
+import com.trove.ticket_trove.dto.ticket.response.TicketInfoResponse;
+import com.trove.ticket_trove.model.entity.concert.ConcertEntity;
+import com.trove.ticket_trove.model.entity.member.MemberEntity;
+import com.trove.ticket_trove.model.entity.seat_grade.SeatGradeEntity;
+import com.trove.ticket_trove.model.entity.ticket.TicketEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TicketRepository extends JpaRepository<TicketEntity, Long> {
+
+    @Query("SELECT t " +
+            "FROM TicketEntity t " +
+            "WHERE t.concertId = :concertId " +
+                "AND t.seatGrade = :seatGrade " +
+                "AND t.memberEmail = :memberEmail " +
+                "AND t.seatNumber = :seatNumber")
+    Optional<TicketEntity> findByConcertIdAndSeatGradeAndMemberEmailAndSeatNumber(
+            @Param("concertId") ConcertEntity concertId,
+            @Param("seatGrade") SeatGradeEntity seatGrade,
+            @Param("memberEmail") MemberEntity memberEmail,
+            @Param("seatNumber") Integer seatNumber);
+
+    List<TicketEntity> findByMemberEmail(MemberEntity memberEntity);
+
+    List<TicketEntity> findByConcertId(ConcertEntity concertId);
+}

--- a/src/main/java/com/trove/ticket_trove/service/reservation/ReservationService.java
+++ b/src/main/java/com/trove/ticket_trove/service/reservation/ReservationService.java
@@ -1,0 +1,188 @@
+package com.trove.ticket_trove.service.reservation;
+
+import com.trove.ticket_trove.dto.ticket.request.TicketCreateRequest;
+import com.trove.ticket_trove.dto.ticket.request.TicketDeleteRequest;
+import com.trove.ticket_trove.dto.ticket.request.TicketSearchRequest;
+import com.trove.ticket_trove.dto.ticket.response.TicketInfoAdminResponse;
+import com.trove.ticket_trove.dto.ticket.response.TicketInfoResponse;
+import com.trove.ticket_trove.dto.ticket.response.TicketReservationResponse;
+import com.trove.ticket_trove.exception.concert.ConcertNotFoundException;
+import com.trove.ticket_trove.exception.member.MemberNotFoundException;
+import com.trove.ticket_trove.exception.seatgrade.SeatGradeNotFoundException;
+import com.trove.ticket_trove.exception.seatgrade.SeatNumberValidationException;
+import com.trove.ticket_trove.exception.ticket.TicketExistsException;
+import com.trove.ticket_trove.exception.ticket.TicketNotFoundException;
+import com.trove.ticket_trove.model.entity.concert.ConcertEntity;
+import com.trove.ticket_trove.model.entity.member.MemberEntity;
+import com.trove.ticket_trove.model.entity.seat_grade.SeatGradeEntity;
+import com.trove.ticket_trove.model.entity.ticket.TicketEntity;
+import com.trove.ticket_trove.model.storage.concert.ConcertRepository;
+import com.trove.ticket_trove.model.storage.member.MemberRepository;
+import com.trove.ticket_trove.model.storage.seat_grade.SeatGradeRepository;
+import com.trove.ticket_trove.model.storage.ticket.TicketRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ReservationService {
+    private final TicketRepository ticketRepository;
+    private final ConcertRepository concertRepository;
+    private final MemberRepository memberRepository;
+    private final SeatGradeRepository seatGradeRepository;
+
+    public ReservationService(
+            TicketRepository ticketRepository,
+            ConcertRepository concertRepository,
+            MemberRepository memberRepository,
+            SeatGradeRepository seatGradeRepository) {
+
+        this.ticketRepository = ticketRepository;
+        this.concertRepository = concertRepository;
+        this.memberRepository = memberRepository;
+        this.seatGradeRepository = seatGradeRepository;
+    }
+
+    //티켓 예매
+    @Transactional
+    public TicketReservationResponse reserve(
+            TicketCreateRequest request
+    ) {
+
+        var ticket = createTicketEntity(
+                request.concertId(), request.email(),
+                request.seatGrade(), request.seatNumber());
+
+        //유효성 검사
+        validateSeat(
+                ticket.getSeatGrade(),
+                ticket.getSeatNumber());
+        validateTicket(
+                ticket.getConcertId(),
+                ticket.getSeatGrade(),
+                ticket.getMemberEmail(),
+                ticket.getSeatNumber());
+
+        return TicketReservationResponse
+                .from(ticketRepository.save(ticket));
+    }
+
+    //유저 티켓 전체 조회 (유저)
+    public List<TicketInfoResponse> searchTickets(String email) { //시큐리티 적용시 수정할 예정
+        var memberEntity = getMemberEntity(email);
+        return ticketRepository
+                .findByMemberEmail(memberEntity)
+                .stream()
+                .map(TicketInfoResponse::from)
+                .toList();
+    }
+
+    //공연장 티켓 전체 조회(관리자)
+    public List<TicketInfoAdminResponse> searchConcertTickets(Long concertId) {
+        var concertEntity = getConcertEntity(concertId);
+        return ticketRepository
+                .findByConcertId(concertEntity)
+                .stream().map(TicketInfoAdminResponse::from)
+                .toList();
+    }
+
+    //티켓 단건 조회
+    public TicketInfoResponse searchTicket(TicketSearchRequest request) {
+
+        var ticket = createTicketEntity(
+                request.concertId(), request.email(),
+                request.seatGrade(), request.seatNumber());
+
+        var ticketEntity = getTicketEntity(
+                ticket.getConcertId(), ticket.getSeatGrade(),
+                ticket.getMemberEmail(), ticket.getSeatNumber());
+
+        return TicketInfoResponse.from(ticketEntity);
+    }
+
+    //티켓 예매 취소
+    @Transactional
+    public void cancelTicket(TicketDeleteRequest request) {
+
+        var ticket = createTicketEntity(
+                request.concertId(), request.email(),
+                request.seatGrade(), request.seatNumber());
+
+        var ticketEntity = getTicketEntity(
+                ticket.getConcertId(), ticket.getSeatGrade(),
+                ticket.getMemberEmail(), ticket.getSeatNumber());
+
+        ticketRepository.delete(ticketEntity);
+    }
+
+    //등급의 좌석수보다 높으면 예외
+    private void validateSeat(
+            SeatGradeEntity seatGradeEntity,
+            Integer seatNumber) {
+
+        if(seatNumber > seatGradeEntity.getTotalSeat())
+            throw new SeatNumberValidationException();
+        else if(seatNumber < 1)
+            throw new SeatNumberValidationException();
+    }
+
+    //이미 존재하는 티켓인지 확인
+    private void validateTicket(
+            ConcertEntity concertEntity,
+            SeatGradeEntity seatGradeEntity,
+            MemberEntity memberEntity,
+            Integer seatNumber) {
+
+        ticketRepository.findByConcertIdAndSeatGradeAndMemberEmailAndSeatNumber(
+                        concertEntity, seatGradeEntity, memberEntity, seatNumber)
+                .ifPresent(ticket -> {throw new TicketExistsException();});
+    }
+
+    //Ticket 객체를 생성하는 메소드
+    private TicketEntity createTicketEntity(
+            Long concertId, String email,
+            String grade, Integer seatNumber) {
+
+        var concertEntity = getConcertEntity(concertId);
+        var seatGradeEntity =
+                getSeatGradeEntity(concertEntity, grade.toUpperCase());
+        var memberEntity = getMemberEntity(email);
+
+        return TicketEntity.from(
+                memberEntity, concertEntity,
+                seatGradeEntity, seatNumber);
+    }
+
+    //DB에 저장된 Ticket 조회해서 가져오는 메소드
+    private TicketEntity getTicketEntity(
+            ConcertEntity concertEntity,
+            SeatGradeEntity seatGradeEntity,
+            MemberEntity memberEntity,
+            Integer seatNumber) {
+
+        return ticketRepository.findByConcertIdAndSeatGradeAndMemberEmailAndSeatNumber(
+                concertEntity, seatGradeEntity, memberEntity, seatNumber)
+                .orElseThrow(TicketNotFoundException::new);
+    }
+
+    private ConcertEntity getConcertEntity(Long concertId) {
+        return concertRepository
+                .findById(concertId)
+                .orElseThrow(ConcertNotFoundException::new);
+    }
+
+    private SeatGradeEntity getSeatGradeEntity(
+            ConcertEntity concertEntity,
+            String grade) {
+        return seatGradeRepository
+                .findByConcertIdAndGrade(
+                        concertEntity, grade.toUpperCase())
+                .orElseThrow(SeatGradeNotFoundException::new);
+    }
+
+    private MemberEntity getMemberEntity(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+}


### PR DESCRIPTION
[컨트롤러 추가] ReservationController 추가
 - /api/v1/reservation을 맵핑으로 한다.
 - CRUD 구현
[DTO 추가] ticketDTO 추가
[서비스 추가] ReservationService 추가
 - CRUD 구현
[DTO 수정] memberDTO validation 추가
[DTO 수정] concertDTO validation 추가하고 변수명 추가
[서비스 클래스 수정] ConcertService에 SeatGradeRepository추가
[엔티티 구현] TicketEntity와 TicketRepository 구현
[엔티티 구현] SeatGradeEntity와 SeatGradeRepository 구현





close #15 