### PR TITLE
[서비스 수정] #17 ConcertController delete 메소드 에러

### DIFF
--- a/src/main/java/com/trove/ticket_trove/service/concert/ConcertService.java
+++ b/src/main/java/com/trove/ticket_trove/service/concert/ConcertService.java
@@ -11,6 +11,7 @@ import com.trove.ticket_trove.model.entity.seat_grade.SeatGradeEntity;
 import com.trove.ticket_trove.model.storage.concert.ConcertRepository;
 import com.trove.ticket_trove.model.storage.seat_grade.SeatGradeRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
 
 import java.util.Arrays;
@@ -30,6 +31,7 @@ public class ConcertService {
         this.seatGradeRepository = seatGradeRepository;
     }
 
+    @Transactional
     //콘서트 생성
     public void addConcert(ConcertCreateRequest request) {
         validateConcert(request.concertName(), request.performer());
@@ -51,6 +53,7 @@ public class ConcertService {
         ).forEach(seatGradeRepository::save);
     }
 
+    @Transactional
     //콘서트 정보 수정
     public ConcertUpdateResponse updateConcert(ConcertUpdateRequest request) {
         var concertEntity = getConcertEntity(request.concertId());
@@ -82,6 +85,7 @@ public class ConcertService {
         return ConcertInfoResponse.from(getConcertEntity(id));
     }
 
+    @Transactional
     //콘서트 정보 삭제
     public void deleteConcert(Long id) {
         var concertEntity = getConcertEntity(id);

--- a/src/main/java/com/trove/ticket_trove/service/login/LoginService.java
+++ b/src/main/java/com/trove/ticket_trove/service/login/LoginService.java
@@ -9,6 +9,7 @@ import com.trove.ticket_trove.model.entity.member.MemberEntity;
 import com.trove.ticket_trove.model.storage.member.MemberRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class LoginService {
@@ -18,7 +19,9 @@ public class LoginService {
     public LoginService(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }
+
     //회원가입
+    @Transactional
     public MemberEntity signup(MemberSignupRequest request) {
         validateExistsEmail(request.email());
         var memberEntity = MemberEntity.from(


### PR DESCRIPTION

"No EntityManager with actual transaction available for current thread - cannot reliably process 'remove' call"
에러로 인한 
ConcertService.deletedConcert()에 트랜젝션 @Transectional어노테이션 추가 



close #17 